### PR TITLE
Call [super viewDidAppear:] in -[PCNameViewController viewDidAppear:]

### DIFF
--- a/PunchClock/PCNameViewController.m
+++ b/PunchClock/PCNameViewController.m
@@ -19,6 +19,8 @@
 
 - (void)viewDidAppear:(BOOL)animated
 {
+	[super viewDidAppear:animated];
+
 	self.nameField.layer.cornerRadius = 3.0;
 	
 	self.nameField.text = [[NSUserDefaults standardUserDefaults] stringForKey:@"username"];


### PR DESCRIPTION
This is a very minor issue, but it's the only issue caught by the clang analyzer, which now seems to run automatically sometimes in Xcode 6.
