### PR TITLE
Allow spaces in names

### DIFF
--- a/PunchClock/PCStatusTableDataSource.m
+++ b/PunchClock/PCStatusTableDataSource.m
@@ -114,7 +114,8 @@ static NSString *cellIdentifier = @"StatusTableCell";
 
 		// Image
 		NSString *username = [person objectForKey:@"name"];
-		NSString *imageURL = [NSString stringWithFormat:@"%@/image/%@", PCbaseURL, username];
+        NSString *encodedUsername = [username stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+		NSString *imageURL = [NSString stringWithFormat:@"%@/image/%@", PCbaseURL, encodedUsername];
 
 		AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
 		[serializer setAuthorizationHeaderFieldWithUsername:backendUsername password:backendPassword];


### PR DESCRIPTION
This ensures that the name is properly URL encoded before trying
to fetch an image from the server. Without this the app crashes
when a space is used in the name.
