### PR TITLE
hide bell for own user

### DIFF
--- a/PunchClock/PCStatusTableDataSource.m
+++ b/PunchClock/PCStatusTableDataSource.m
@@ -145,7 +145,10 @@ static NSString *cellIdentifier = @"StatusTableCell";
 		NSNumber *watched_by_value = (NSNumber *)[person objectForKey:@"watched_by_requestor"];
 		bell.selected = [watched_by_value boolValue];
 
-		if ([push_id isEqualToString:@""]) {
+		NSString *ownUsername = [[defaults valueForKey:@"username"] lowercaseString];
+		BOOL cellIsOwnUser = [[username lowercaseString] isEqualToString:ownUsername];
+
+		if ([push_id isEqualToString:@""] || cellIsOwnUser) {
 			bell.hidden = YES;
 		}
 


### PR DESCRIPTION
Currently when you try to watch yourself the app crashes, here we simply hide the bell if the name matches our own username
