### PR TITLE
Make avatars round with corner radius

### DIFF
--- a/PunchClock/PCStatusTableDataSource.m
+++ b/PunchClock/PCStatusTableDataSource.m
@@ -124,6 +124,8 @@ static NSString *cellIdentifier = @"StatusTableCell";
 
 
 		UIImageView *imageView = (UIImageView *)[cell viewWithTag:3];
+		[imageView.layer setCornerRadius:imageView.frame.size.width / 2];
+		[imageView setClipsToBounds:YES];
 		[imageView setImageWithURLRequest:URLRequest
 						 placeholderImage:[UIImage imageNamed:@"unknown"]
 								  success:nil


### PR DESCRIPTION
The design lends itself better to round avatars like in the screenshot on the Readme (just like all the Panic teams avatars)
