### PR TITLE
display the messages in a table in the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ xcuserdata/
 PunchClock/constants.h
 /PunchClock/PunchClock_Beta.xcconfig
 /PunchClock/PunchClock_Debug.xcconfig
+PunchClock.xcworkspace/xcshareddata/

--- a/PunchClock.xcodeproj/project.pbxproj
+++ b/PunchClock.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		073D18A6197DDAFE00B92209 /* PCMessagesTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 073D18A5197DDAFE00B92209 /* PCMessagesTableViewController.m */; };
+		073D18A9197DDC1100B92209 /* PCTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 073D18A8197DDC1100B92209 /* PCTableViewController.m */; };
+		073D18AC197DE41B00B92209 /* PCMessageTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 073D18AB197DE41B00B92209 /* PCMessageTableViewCell.m */; };
 		1A01C2171857E2080089B546 /* PCStatusTableDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A01C2161857E2080089B546 /* PCStatusTableDataSource.m */; };
 		1A30A7EC18FDE76D002FB8E9 /* PCFileFunctionLevelFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A30A7EB18FDE76D002FB8E9 /* PCFileFunctionLevelFormatter.m */; };
 		1A31D8691858D13700BA2CFE /* PCStatusTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A31D8681858D13700BA2CFE /* PCStatusTableViewController.m */; };
@@ -36,6 +39,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		073D18A4197DDAFE00B92209 /* PCMessagesTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMessagesTableViewController.h; sourceTree = "<group>"; };
+		073D18A5197DDAFE00B92209 /* PCMessagesTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PCMessagesTableViewController.m; sourceTree = "<group>"; };
+		073D18A7197DDC1100B92209 /* PCTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCTableViewController.h; sourceTree = "<group>"; };
+		073D18A8197DDC1100B92209 /* PCTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PCTableViewController.m; sourceTree = "<group>"; };
+		073D18AA197DE41B00B92209 /* PCMessageTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMessageTableViewCell.h; sourceTree = "<group>"; };
+		073D18AB197DE41B00B92209 /* PCMessageTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PCMessageTableViewCell.m; sourceTree = "<group>"; };
 		1A01C2151857E2080089B546 /* PCStatusTableDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCStatusTableDataSource.h; sourceTree = "<group>"; };
 		1A01C2161857E2080089B546 /* PCStatusTableDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PCStatusTableDataSource.m; sourceTree = "<group>"; };
 		1A30A7EA18FDE76D002FB8E9 /* PCFileFunctionLevelFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCFileFunctionLevelFormatter.h; sourceTree = "<group>"; };
@@ -126,6 +135,12 @@
 				1A631DD118D77AF6004B7D90 /* PCTabBarController.m */,
 				1A4CF3B618E24E2C0086BCC0 /* PCMessageFormViewController.h */,
 				1A4CF3B718E24E2C0086BCC0 /* PCMessageFormViewController.m */,
+				073D18A4197DDAFE00B92209 /* PCMessagesTableViewController.h */,
+				073D18A5197DDAFE00B92209 /* PCMessagesTableViewController.m */,
+				073D18A7197DDC1100B92209 /* PCTableViewController.h */,
+				073D18A8197DDC1100B92209 /* PCTableViewController.m */,
+				073D18AA197DE41B00B92209 /* PCMessageTableViewCell.h */,
+				073D18AB197DE41B00B92209 /* PCMessageTableViewCell.m */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -361,15 +376,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				1AD4978F18D2279100817DD3 /* PCNameViewController.m in Sources */,
+				073D18A6197DDAFE00B92209 /* PCMessagesTableViewController.m in Sources */,
 				1A791DBD18442884000943E4 /* main.m in Sources */,
 				1A5E10FA18779CB30079CC56 /* PCStatusLabel.m in Sources */,
 				1A4C2982184DACE300CD0868 /* PCLocationManager.m in Sources */,
 				1A631DD218D77AF6004B7D90 /* PCTabBarController.m in Sources */,
+				073D18A9197DDC1100B92209 /* PCTableViewController.m in Sources */,
 				1A791DC718442884000943E4 /* PCLocationTableViewController.m in Sources */,
 				1A30A7EC18FDE76D002FB8E9 /* PCFileFunctionLevelFormatter.m in Sources */,
 				1A01C2171857E2080089B546 /* PCStatusTableDataSource.m in Sources */,
 				1A4CF3C018E3812E0086BCC0 /* UIView+Borders.m in Sources */,
 				1A4CF3B818E24E2C0086BCC0 /* PCMessageFormViewController.m in Sources */,
+				073D18AC197DE41B00B92209 /* PCMessageTableViewCell.m in Sources */,
 				1A31D8691858D13700BA2CFE /* PCStatusTableViewController.m in Sources */,
 				1A791DC118442884000943E4 /* PCAppDelegate.m in Sources */,
 			);

--- a/PunchClock/Base.lproj/Main.storyboard
+++ b/PunchClock/Base.lproj/Main.storyboard
@@ -409,11 +409,165 @@
                     <connections>
                         <segue destination="fDc-ah-AGI" kind="relationship" relationship="viewControllers" id="5va-7J-dwt"/>
                         <segue destination="T2N-Si-LxJ" kind="relationship" relationship="viewControllers" id="zRV-q7-10M"/>
+                        <segue destination="L2I-VZ-26m" kind="relationship" relationship="viewControllers" id="2yB-RY-Siz"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8g5-Hj-Hx9" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="495" y="536"/>
+        </scene>
+        <!--Messages Table View Controller - Messages-->
+        <scene sceneID="9w8-L1-4rT">
+            <objects>
+                <viewController id="L2I-VZ-26m" customClass="PCMessagesTableViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="loW-jA-oS3"/>
+                        <viewControllerLayoutGuide type="bottom" id="VFE-gO-tgJ"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="nkq-Tm-jUG">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="519"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pcd-Ij-1GP">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="519"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJ6-EX-HOd" userLabel="Status View">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
+                                        <color key="backgroundColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="myM-y6-NgQ" userLabel="Toolbar">
+                                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                                        <subviews>
+                                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading…" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zxp-S6-jHC">
+                                                <rect key="frame" x="124" y="12" width="81" height="21"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="centerY" secondItem="Zxp-S6-jHC" secondAttribute="centerY" id="fHa-Ha-GEw"/>
+                                            <constraint firstAttribute="centerX" secondItem="Zxp-S6-jHC" secondAttribute="centerX" constant="-4.5" id="yBb-vX-oPh"/>
+                                        </constraints>
+                                    </view>
+                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GWw-Ys-4uO">
+                                        <rect key="frame" x="0.0" y="64" width="320" height="455"/>
+                                        <subviews>
+                                            <tableView clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="74" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="SPP-wI-frk">
+                                                <rect key="frame" x="0.0" y="0.0" width="320" height="455"/>
+                                                <color key="backgroundColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                                <color key="separatorColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                                <inset key="separatorInset" minX="15" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                <prototypes>
+                                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="MessageTableCell" id="3ec-DJ-wI0" customClass="PCMessageTableViewCell">
+                                                        <rect key="frame" x="0.0" y="22" width="320" height="74"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3ec-DJ-wI0" id="ieb-47-WVJ">
+                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                            <subviews>
+                                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="James" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qqh-Hk-V2C">
+                                                                    <rect key="frame" x="52" y="7" width="80" height="21"/>
+                                                                    <color key="backgroundColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="80" id="Tzc-k9-ANT"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <imageView userInteractionEnabled="NO" tag="3" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="unknown" translatesAutoresizingMaskIntoConstraints="NO" id="BWg-LI-dON">
+                                                                    <rect key="frame" x="12" y="21" width="32" height="32"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="32" id="6zY-jO-6DX"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Hey peeps, I'm running a bit late but I'll be there at around 10." translatesAutoresizingMaskIntoConstraints="NO" id="nTL-9Y-cRG">
+                                                                    <rect key="frame" x="52" y="21" width="261" height="53"/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                                </textView>
+                                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="21 Jul 12:21am" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="12t-k0-WXK">
+                                                                    <rect key="frame" x="200" y="7" width="105" height="21"/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="105" id="P9V-RZ-yMt"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                                            <constraints>
+                                                                <constraint firstItem="BWg-LI-dON" firstAttribute="top" secondItem="nTL-9Y-cRG" secondAttribute="top" id="48g-bh-rk9"/>
+                                                                <constraint firstItem="12t-k0-WXK" firstAttribute="top" secondItem="qqh-Hk-V2C" secondAttribute="top" id="6Wf-yj-q8q"/>
+                                                                <constraint firstItem="BWg-LI-dON" firstAttribute="leading" secondItem="ieb-47-WVJ" secondAttribute="leading" constant="12" id="8kR-V2-zUA"/>
+                                                                <constraint firstItem="qqh-Hk-V2C" firstAttribute="leading" secondItem="BWg-LI-dON" secondAttribute="trailing" constant="8" symbolic="YES" id="HMe-fQ-qxY"/>
+                                                                <constraint firstItem="qqh-Hk-V2C" firstAttribute="top" secondItem="ieb-47-WVJ" secondAttribute="top" constant="7" id="WY5-DU-DHD"/>
+                                                                <constraint firstItem="nTL-9Y-cRG" firstAttribute="leading" secondItem="BWg-LI-dON" secondAttribute="trailing" constant="8" symbolic="YES" id="bJe-aZ-uc7"/>
+                                                                <constraint firstItem="qqh-Hk-V2C" firstAttribute="bottom" secondItem="12t-k0-WXK" secondAttribute="bottom" id="cn6-wN-uBU"/>
+                                                                <constraint firstAttribute="bottom" secondItem="BWg-LI-dON" secondAttribute="bottom" constant="20" symbolic="YES" id="cnm-XB-ZKb"/>
+                                                                <constraint firstAttribute="trailing" secondItem="12t-k0-WXK" secondAttribute="trailing" constant="15" id="ft3-og-9og"/>
+                                                                <constraint firstAttribute="trailing" secondItem="nTL-9Y-cRG" secondAttribute="trailing" constant="7" id="kK4-06-L1i"/>
+                                                                <constraint firstItem="BWg-LI-dON" firstAttribute="top" secondItem="ieb-47-WVJ" secondAttribute="top" constant="21" id="ktZ-hO-u3G"/>
+                                                                <constraint firstAttribute="bottom" secondItem="nTL-9Y-cRG" secondAttribute="bottom" constant="-1" id="pap-JQ-mSj"/>
+                                                            </constraints>
+                                                        </tableViewCellContentView>
+                                                        <color key="backgroundColor" red="0.270588249" green="0.18823531269999999" blue="0.26274511220000002" alpha="1" colorSpace="deviceRGB"/>
+                                                        <connections>
+                                                            <outlet property="avatarImageView" destination="BWg-LI-dON" id="Eru-9x-oYF"/>
+                                                            <outlet property="dateLabel" destination="12t-k0-WXK" id="R0F-6p-BBd"/>
+                                                            <outlet property="messageTextView" destination="nTL-9Y-cRG" id="K5D-j2-kl0"/>
+                                                            <outlet property="nameLabel" destination="qqh-Hk-V2C" id="cmV-vf-wJR"/>
+                                                        </connections>
+                                                    </tableViewCell>
+                                                </prototypes>
+                                            </tableView>
+                                        </subviews>
+                                    </scrollView>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="trailing" secondItem="GWw-Ys-4uO" secondAttribute="trailing" id="1yS-5V-Q5e"/>
+                                    <constraint firstItem="bJ6-EX-HOd" firstAttribute="top" secondItem="pcd-Ij-1GP" secondAttribute="top" id="5i3-tC-pt6"/>
+                                    <constraint firstAttribute="bottom" secondItem="GWw-Ys-4uO" secondAttribute="bottom" id="BWJ-sn-oKb"/>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="leading" secondItem="GWw-Ys-4uO" secondAttribute="leading" id="Ege-Ca-5iR"/>
+                                    <constraint firstAttribute="centerX" secondItem="myM-y6-NgQ" secondAttribute="centerX" id="R6d-ZW-YzC"/>
+                                    <constraint firstItem="GWw-Ys-4uO" firstAttribute="top" secondItem="myM-y6-NgQ" secondAttribute="bottom" id="Y9a-19-xrG"/>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="leading" secondItem="pcd-Ij-1GP" secondAttribute="leading" id="bNT-RP-DY4"/>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="leading" secondItem="bJ6-EX-HOd" secondAttribute="leading" id="c5F-06-z0S"/>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="top" secondItem="pcd-Ij-1GP" secondAttribute="top" constant="20" symbolic="YES" id="cHy-DR-m93"/>
+                                    <constraint firstAttribute="bottom" secondItem="myM-y6-NgQ" secondAttribute="bottom" constant="455" id="cbn-Hd-gLb"/>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="top" secondItem="bJ6-EX-HOd" secondAttribute="bottom" id="plj-ZT-egF"/>
+                                    <constraint firstItem="myM-y6-NgQ" firstAttribute="trailing" secondItem="bJ6-EX-HOd" secondAttribute="trailing" id="vIL-P2-gxu"/>
+                                    <constraint firstAttribute="trailing" secondItem="myM-y6-NgQ" secondAttribute="trailing" id="vZx-db-NW0"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="pcd-Ij-1GP" firstAttribute="leading" secondItem="nkq-Tm-jUG" secondAttribute="leading" id="EkS-JP-IBU"/>
+                            <constraint firstAttribute="bottom" secondItem="pcd-Ij-1GP" secondAttribute="bottom" id="RtI-dc-HO1"/>
+                            <constraint firstAttribute="trailing" secondItem="pcd-Ij-1GP" secondAttribute="trailing" id="cxJ-gZ-1aU"/>
+                            <constraint firstItem="pcd-Ij-1GP" firstAttribute="top" secondItem="nkq-Tm-jUG" secondAttribute="top" id="klk-sc-dcE"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Messages" image="message" id="B9u-P7-a8e"/>
+                    <connections>
+                        <outlet property="tableView" destination="SPP-wI-frk" id="v4Q-vB-gd6"/>
+                        <outlet property="toolbarTitle" destination="Zxp-S6-jHC" id="NJg-4H-HQX"/>
+                        <outlet property="topToolbar" destination="myM-y6-NgQ" id="tIh-jV-Ngs"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="btc-eO-0iR" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1029" y="1576"/>
         </scene>
         <!--Status Table View Controller - Team-->
         <scene sceneID="fxV-jx-bWd">
@@ -517,9 +671,9 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="VOS-f3-3eO" firstAttribute="top" secondItem="pzl-rx-y5P" secondAttribute="bottom" id="41B-S8-oal"/>
+                            <constraint firstItem="AR2-Nn-z3m" firstAttribute="top" secondItem="VOS-f3-3eO" secondAttribute="bottom" constant="455" id="91b-l0-ECU"/>
+                            <constraint firstItem="VOS-f3-3eO" firstAttribute="top" secondItem="pzl-rx-y5P" secondAttribute="bottom" id="IZc-uR-PCB"/>
                             <constraint firstAttribute="centerX" secondItem="VOS-f3-3eO" secondAttribute="centerX" id="TeZ-km-sTj"/>
-                            <constraint firstItem="AR2-Nn-z3m" firstAttribute="top" secondItem="VOS-f3-3eO" secondAttribute="bottom" constant="455" id="jPw-zt-vJ6"/>
                             <constraint firstItem="VOS-f3-3eO" firstAttribute="leading" secondItem="dE6-QQ-SxI" secondAttribute="leading" id="u2E-e3-e8e"/>
                             <constraint firstAttribute="trailing" secondItem="VOS-f3-3eO" secondAttribute="trailing" id="zQG-Mx-Cmp"/>
                         </constraints>

--- a/PunchClock/PCMessageTableViewCell.h
+++ b/PunchClock/PCMessageTableViewCell.h
@@ -1,0 +1,18 @@
+//
+//  PCMessageTableViewCell.h
+//  PunchClock
+//
+//  Created by Jurre Stender on 22/07/14.
+//  Copyright (c) 2014 Panic Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface PCMessageTableViewCell : UITableViewCell
+
+@property (nonatomic, strong) IBOutlet UILabel *nameLabel;
+@property (nonatomic, strong) IBOutlet UITextView *messageTextView;
+@property (nonatomic, strong) IBOutlet UIImageView *avatarImageView;
+@property (nonatomic, strong) IBOutlet UILabel *dateLabel;
+
+@end

--- a/PunchClock/PCMessageTableViewCell.m
+++ b/PunchClock/PCMessageTableViewCell.m
@@ -1,0 +1,13 @@
+//
+//  PCMessageTableViewCell.m
+//  PunchClock
+//
+//  Created by Jurre Stender on 22/07/14.
+//  Copyright (c) 2014 Panic Inc. All rights reserved.
+//
+
+#import "PCMessageTableViewCell.h"
+
+@implementation PCMessageTableViewCell
+
+@end

--- a/PunchClock/PCMessagesTableViewController.h
+++ b/PunchClock/PCMessagesTableViewController.h
@@ -1,0 +1,14 @@
+//
+//  PCMessagesViewController.h
+//  PunchClock
+//
+//  Created by Jurre Stender on 22/07/14.
+//  Copyright (c) 2014 Panic Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "PCTableViewController.h"
+
+@interface PCMessagesTableViewController : PCTableViewController
+
+@end

--- a/PunchClock/PCMessagesTableViewController.m
+++ b/PunchClock/PCMessagesTableViewController.m
@@ -1,0 +1,139 @@
+//
+//  PCMessagesViewController.m
+//  PunchClock
+//
+//  Created by Jurre Stender on 22/07/14.
+//  Copyright (c) 2014 Panic Inc. All rights reserved.
+//
+
+#import "PCMessagesTableViewController.h"
+#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/UIImageView+AFNetworking.h>
+#import "PCMessageTableViewCell.h"
+
+@interface PCMessagesTableViewController () <UITableViewDelegate, UITableViewDataSource>
+
+@property (nonatomic, strong) NSArray *messages;
+
+@end
+
+@implementation PCMessagesTableViewController
+
+static NSString *cellIdentifier = @"MessageTableCell";
+
+- (void)viewDidLoad
+{
+	[super viewDidLoad];
+	self.tableView.dataSource = self;
+	self.tableView.delegate = self;
+
+	[self refreshData:self];
+}
+
+- (void)refreshData:(id)sender
+{
+	AFHTTPRequestOperationManager *manager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:[NSURL URLWithString:PCbaseURL]];
+	[manager.requestSerializer setAuthorizationHeaderFieldWithUsername:backendUsername password:backendPassword];
+
+	NSMutableURLRequest *request = [manager.requestSerializer requestWithMethod:@"GET"
+																	  URLString:[NSString stringWithFormat:@"%@/messages", PCbaseURL]
+																	 parameters:@{}
+																		  error:nil];
+
+
+    AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    operation.responseSerializer = [AFJSONResponseSerializer serializer];
+
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *requestOperation, id responseObject) {
+
+        self.messages = (NSArray *)responseObject;
+		[self.tableView reloadData];
+		self.toolbarTitle.text = @"Messages";
+		[self.refreshControl endRefreshing];
+
+    } failure:^(AFHTTPRequestOperation *requestOperation, NSError *error) {
+		DDLogError(@"Fetching Messages failed: %@", error.localizedDescription);
+		[self.refreshControl endRefreshing];
+		self.toolbarTitle.text = @"Messages";
+    }];
+
+    [operation start];
+}
+
+#pragma mark - UITableView Delegate/Datasource
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+	if (!self.messages) {
+		return 0;
+	}
+	
+	return self.messages.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+	PCMessageTableViewCell *cell = (PCMessageTableViewCell *)[self.tableView dequeueReusableCellWithIdentifier:cellIdentifier];
+
+	NSDictionary *message = self.messages[indexPath.row];
+
+	NSString *username = message[@"person"][@"name"];
+	NSString *encodedUsername = [username stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+	NSString *imageURL = [NSString stringWithFormat:@"%@/image/%@", PCbaseURL, encodedUsername];
+	
+	AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
+	[serializer setAuthorizationHeaderFieldWithUsername:backendUsername password:backendPassword];
+	NSMutableURLRequest *URLRequest = [serializer requestWithMethod:@"GET" URLString:imageURL parameters:nil error:nil];
+	
+
+	[cell.avatarImageView.layer setCornerRadius:cell.avatarImageView.frame.size.width / 2];
+	[cell.avatarImageView setClipsToBounds:YES];
+	[cell.avatarImageView setImageWithURLRequest:URLRequest
+					 placeholderImage:[UIImage imageNamed:@"unknown"]
+							  success:nil
+							  failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+								  DDLogError(@"image fetch failed: %@\n%@", response, error);
+								  
+							  }];
+
+	cell.nameLabel.text = [username capitalizedString];
+	cell.messageTextView.text = message[@"message"];
+	cell.dateLabel.text = [self formattedStringFromISO8601String:message[@"date"]];
+	return cell;
+}
+
+#pragma mark - Private
+
+- (NSString *)formattedStringFromISO8601String:(NSString *)iso8601String
+{
+	NSDate *date = [[self ISO8601DateFormatter] dateFromString:iso8601String];
+	return [[self displayDateFormatter] stringFromDate:date];
+}
+
+- (NSDateFormatter *)displayDateFormatter
+{
+	static NSDateFormatter *_dateFormatter;
+	if (!_dateFormatter) {
+		_dateFormatter = [[NSDateFormatter alloc] init];
+		[_dateFormatter setDateStyle:NSDateFormatterMediumStyle];
+		[_dateFormatter setTimeStyle:NSDateFormatterShortStyle];
+		[_dateFormatter setLocale:[NSLocale currentLocale]];
+	}
+	return _dateFormatter;
+}
+
+- (NSDateFormatter *)ISO8601DateFormatter
+{
+	static NSDateFormatter *_dateFormatter;
+	if (!_dateFormatter) {
+		_dateFormatter = [[NSDateFormatter alloc] init];
+		[_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
+	}
+	return _dateFormatter;
+}
+
+- (NSDate *)dateFromISO8601String:(NSString *)dateString {
+    return [[self ISO8601DateFormatter] dateFromString:dateString];
+}
+
+@end

--- a/PunchClock/PCStatusTableViewController.h
+++ b/PunchClock/PCStatusTableViewController.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "PCTableViewController.h"
 
-@interface PCStatusTableViewController : UIViewController
+@interface PCStatusTableViewController : PCTableViewController
 
 @end

--- a/PunchClock/PCStatusTableViewController.m
+++ b/PunchClock/PCStatusTableViewController.m
@@ -12,15 +12,10 @@
 #import <MZFormSheetController/MZFormSheetController.h>
 #import <MZFormSheetController/MZFormSheetSegue.h>
 #import "PCMessageFormViewController.h"
-#import "UIView+Borders.h"
 
 @interface PCStatusTableViewController () <MZFormSheetBackgroundWindowDelegate>
 
-@property (strong, nonatomic) IBOutlet UITableView *tableView;
-@property (strong, nonatomic) UIRefreshControl *refreshControl;
 @property (strong, nonatomic) IBOutlet UIButton *messageButton;
-@property (strong, nonatomic) IBOutlet UIView *topToolbar;
-@property (strong, nonatomic) IBOutlet UILabel *toolbarTitle;
 
 @end
 
@@ -120,13 +115,13 @@
 
 - (void)viewDidLoad
 {
-  [super viewDidLoad];
+	[super viewDidLoad];
 
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(refreshData:)
 												 name:UIApplicationDidBecomeActiveNotification
 											   object:nil];
-	
+
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(refreshData:)
 												 name:@"StatusUpdated"
@@ -144,20 +139,12 @@
 		[self performSegueWithIdentifier:@"missingNameStatus" sender:self];
 	}
 
-	UITableViewController *tableViewController = [[UITableViewController alloc] init];
-    tableViewController.tableView = self.tableView;
-
-    self.refreshControl = [[UIRefreshControl alloc] init];
-	self.refreshControl.tintColor = [UIColor whiteColor];
-    [self.refreshControl addTarget:self action:@selector(refreshData:) forControlEvents:UIControlEventValueChanged];
-    tableViewController.refreshControl = self.refreshControl;
 
 	[[MZFormSheetBackgroundWindow appearance] setBackgroundBlurEffect:YES];
     [[MZFormSheetBackgroundWindow appearance] setBlurRadius:5.0];
     [[MZFormSheetBackgroundWindow appearance] setBackgroundColor:[UIColor clearColor]];
 
 
-	[self.topToolbar addBottomBorderWithHeight:0.3f andColor:[UIColor colorWithRed:0.325f green:0.255f blue:0.318f alpha:1.000]];
 
 }
 

--- a/PunchClock/PCTableViewController.h
+++ b/PunchClock/PCTableViewController.h
@@ -1,0 +1,18 @@
+//
+//  PCTableViewController.h
+//  PunchClock
+//
+//  Created by Jurre Stender on 22/07/14.
+//  Copyright (c) 2014 Panic Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface PCTableViewController : UIViewController
+
+@property (strong, nonatomic) IBOutlet UITableView *tableView;
+@property (strong, nonatomic) UIRefreshControl *refreshControl;
+@property (strong, nonatomic) IBOutlet UIView *topToolbar;
+@property (strong, nonatomic) IBOutlet UILabel *toolbarTitle;
+
+@end

--- a/PunchClock/PCTableViewController.m
+++ b/PunchClock/PCTableViewController.m
@@ -1,0 +1,38 @@
+//
+//  PCTableViewController.m
+//  PunchClock
+//
+//  Created by Jurre Stender on 22/07/14.
+//  Copyright (c) 2014 Panic Inc. All rights reserved.
+//
+
+#import "PCTableViewController.h"
+#import "UIView+Borders.h"
+
+@interface PCTableViewController ()
+
+@end
+
+@implementation PCTableViewController
+
+- (void)viewDidLoad
+{
+	[super viewDidLoad];
+	
+	UITableViewController *tableViewController = [[UITableViewController alloc] init];
+    tableViewController.tableView = self.tableView;
+
+    self.refreshControl = [[UIRefreshControl alloc] init];
+	self.refreshControl.tintColor = [UIColor whiteColor];
+    [self.refreshControl addTarget:self action:@selector(refreshData:) forControlEvents:UIControlEventValueChanged];
+    tableViewController.refreshControl = self.refreshControl;
+
+	[self.topToolbar addBottomBorderWithHeight:0.3f andColor:[UIColor colorWithRed:0.325f green:0.255f blue:0.318f alpha:1.000]];
+}
+
+- (void)refreshData:(id)sender
+{
+	[[NSException exceptionWithName:@"Method not implemented" reason:@"-refreshData: should be implemented in subclass" userInfo:nil] raise];
+}
+
+@end


### PR DESCRIPTION
We really enjoy using the messages feature and thought it would be nice to be able to see them in the app as well. There is an [accompanying PR on the server](https://github.com/panicinc/PunchClockServer/pull/8) as well.

This is what it looks like now:

![img_1169](https://cloud.githubusercontent.com/assets/749864/3656273/76eecd92-1184-11e4-81e7-d8aaab23ba02.PNG)

I've pulled out some common code into `PCTableViewController` that both the `PCStatusTableViewController` and the new `PCMessagesTableViewController` use, I was considering pulling out some of the data fetching code into it's own class as well since there is some duplication there now but I figured it was still small enough. Let me know if you'd prefer that though!
