### PR TITLE
Remove HockeyApp and fix broken Xcode builds

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,6 @@ source 'https://github.com/CocoaPods/Specs.git'
 inhibit_all_warnings!
 
 pod 'AFNetworking', '~> 2.0'
-pod 'HockeySDK'
 pod 'KeychainItemWrapper', '~> 1.2'
 pod 'ZeroPush', '~> 2.0'
 pod 'MZFormSheetController', '~> 2.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,7 +25,6 @@ PODS:
   - CocoaLumberjack/Core (1.9.2)
   - CocoaLumberjack/Extensions (1.9.2):
     - CocoaLumberjack/Core
-  - HockeySDK (3.6.1)
   - KeychainItemWrapper (1.2)
   - MZAppearance (1.1.3)
   - MZFormSheetController (2.4.1):

--- a/PunchClock/PCAppDelegate.h
+++ b/PunchClock/PCAppDelegate.h
@@ -8,10 +8,9 @@
 
 @import UIKit;
 #import "PCLocationManager.h"
-#import <HockeySDK/HockeySDK.h>
 #import <ZeroPush/ZeroPush.h>
 
-@interface PCAppDelegate : UIResponder <UIApplicationDelegate, BITHockeyManagerDelegate, ZeroPushDelegate>
+@interface PCAppDelegate : UIResponder <UIApplicationDelegate, ZeroPushDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 @property (nonatomic, strong) PCLocationManager *locationManager;

--- a/PunchClock/PCAppDelegate.m
+++ b/PunchClock/PCAppDelegate.m
@@ -7,7 +7,6 @@
 //
 
 #import "PCAppDelegate.h"
-#import <HockeySDK/HockeySDK.h>
 #import <KeychainItemWrapper/KeychainItemWrapper.h>
 #import <ZeroPush/ZeroPush.h>
 
@@ -27,27 +26,6 @@
 
 	PCFileFunctionLevelFormatter *formatter = [PCFileFunctionLevelFormatter new];
 	[[DDTTYLogger sharedInstance] setLogFormatter:formatter];
-
-	// Hockey
-	[[BITHockeyManager sharedHockeyManager] configureWithBetaIdentifier:hockeyBetaIdentifier
-																											 liveIdentifier:@"00000000000000000000000000000000"
-																														 delegate:self];
-
-	[BITHockeyManager sharedHockeyManager].crashManager.showAlwaysButton = YES;
-
-#ifdef CONFIGURATION_Debug
-	[BITHockeyManager sharedHockeyManager].disableCrashManager = YES;
-	[BITHockeyManager sharedHockeyManager].disableUpdateManager = YES;
-#else
-	[[BITHockeyManager sharedHockeyManager].authenticator setAuthenticationSecret:hockeyAuthenticationSecret];
-	[[BITHockeyManager sharedHockeyManager].authenticator setIdentificationType:BITAuthenticatorIdentificationTypeHockeyAppEmail];
-#endif
-
-	[[BITHockeyManager sharedHockeyManager] startManager];
-
-#ifdef CONFIGURATION_Beta
-	[[BITHockeyManager sharedHockeyManager].authenticator authenticateInstallation];
-#endif
 
 	// Default Settings
 	NSMutableDictionary *settings = [NSMutableDictionary dictionaryWithCapacity:1];

--- a/PunchClock/constants.h.sample
+++ b/PunchClock/constants.h.sample
@@ -19,8 +19,5 @@ static const int ddLogLevel = LOG_LEVEL_WARN;
 #define geoFenceLat 45.522761
 #define geoFenceRadius 30.0
 
-#define hockeyBetaIdentifier @"00000000000000000000000000000000"
-#define hockeyAuthenticationSecret @"00000000000000000000000000000000"
-
 #define zeroPushDevKey @"xxx"
 #define zeroPushProdKey @"xxx"


### PR DESCRIPTION
Hey! First of all, thanks so much for making and open-sourcing this. So useful!

Right now, the project won't build on the latest version of Xcode. Specifically, the problem is HockeySDK; Apple seems to be automatically enabling bitcode support now, and the HockeySDK is distributed through CocoaPods as a compiled framework without bitcode support. There are a number of straight-forward fixes for this, such as disabling bitcode projectwide (which certainly has its merits) or updating the HockeySDK pod to the latest beta version that's been compiled with bitcode support. 

That being said, Apple TestFlight and crash reporting both work pretty well now (this presumably wasn't the case when you last touched this codebase). For our purposes, we decided that flat-out removing HockeyApp and relying on Apple instead was the best move.

This pull request removes all traces of HockeyApp from the application. Fully understand if you have no interest in merging this in, but I figured I'd throw it your way just in case.


